### PR TITLE
Reobtainableの一次翻訳

### DIFF
--- a/Reobtainable/ja-JP.hjson
+++ b/Reobtainable/ja-JP.hjson
@@ -1,0 +1,16 @@
+ItemName: {
+	FirstFractal: ファーストフラクタル
+	GoblinMask: エーテリアンゴブリンのマスク
+	OgreMask: 巨大すぎるオーガのマスク
+	BoringBow: ボーリングボウ
+}
+
+ItemTooltip: {
+	SkeletonBow: 強化された骨の弓
+	BoringBow:
+		'''
+		ドラゴンの炎で矢を点火する。
+        点火された矢は火のデバフを延長し、10%の追加ダメージを与える。
+        また、矢が接触した他の矢にも点火する。
+		'''
+}

--- a/TranslatedMods.csv
+++ b/TranslatedMods.csv
@@ -201,12 +201,13 @@ steam_id,display_name,internal_name,version,translators,note
 3114886209,Ragnarok,RagnarokMod,1.4.3.2,Hurugitune,全て翻訳済み。ほとんど推敲済み。
 2981525206,Rain Overhaul,RainOverhaul,1.7,ぽぷのべり,
 3400340796,Rare Drop Notification,RareDropNotification,1.6.2,HAKU、ぽぷのべり(バージョン更新対応),
-3427152309,Revengeance+,RevengeancePlus,0.3,Hurugitune,全て翻訳済み。
 3172916251,Realistic Sky,RealisticSky,1.0.24,ぽぷのべり,
 2619954303,Recipe Browser,RecipeBrowser,0.10.10.1,sysnote8,
 3451139077,Recipe Viewer,MultiCrafting,1.2.2,Hurugitune,
 3301034468,Remember To Drink Water!,DrinkWater,0.1,Hurugitune,全て翻訳済み
 2861542679,Remnants,Remnants,2.0.2.1,Hurugitune,
+2557985156,Reobtainable,Reobtainable,1.1.0.2,katudonsan,厳密にはコンテンツ追加無し。テラリア内部のキーを翻訳した模様
+3427152309,Revengeance+,RevengeancePlus,0.3,Hurugitune,全て翻訳済み。
 3168223097,Roommates,Roommates,3.2.0.1,ぽぷのべり,
 2975417797,Shared Health,CombinedHealth,1.3.0,Hurugitune,すべて翻訳済み
 2815010161,Shared World Map,SharedMap,0.1.4.3,Hurugitune,すべて翻訳済み


### PR DESCRIPTION
## 概要

Reobtainableの翻訳を追加しました。
TranslatedMods.csvを修正（※順番ミスの修正も行っています。）

## 新たに翻訳した Mod

- Reobtainable

## セルフチェック

- [x] tModLoader で起動を確認した
- [x] TranslatedMods.csv の対応する Mod の行を正しく編集した
- [x] 機械翻訳のままではなく、全ての内容を確認し、必要に応じて修正した

## 備考

厳密には対応するテラリアの未実装アイテムのキーを翻訳しました。
ファイル名がその影響で命名規則を違反しております。