### PR TITLE
DayDeathCounterModの翻訳を追加（d5991様より）

### DIFF
--- a/DayDeathCounter/ja-JP_Mods.DayDeathCounter.hjson
+++ b/DayDeathCounter/ja-JP_Mods.DayDeathCounter.hjson
@@ -1,0 +1,131 @@
+Configs: {
+	LanguageConfig: {
+		DisplayName: カウンターの言語
+
+		Language: {
+			Label: カウンターの言語
+			Tooltip:
+				'''
+				画面上に表示される「日数／死亡数」の言語を変更します
+				「自動」を選択するとゲームの言語を使用します
+				特定の言語を選択すると、ゲームの言語設定を上書きできます
+				'''
+		}
+	}
+
+	CounterConfig: {
+		DisplayName: カウンターの位置
+
+		Headers: {
+			Movement: 動き
+			Position: 位置
+		}
+
+		Draggable: {
+			Label: ドラッグで動かせる
+			Tooltip: インベントリを開いた状態でカウンターをドラッグすると動かせるようになります
+		}
+
+		Anchor: {
+			Label: 画面
+			Tooltip:
+				'''
+				カウンターが画面のどの隅を基準とするか変更します
+				横/縦の位置はこの隅からの位置を基準とします
+				'''
+		}
+
+		PositionX: {
+			Label: 横の位置
+			Tooltip: 選択した隅から横方向にピクセル単位で移動させます
+		}
+
+		PositionY: {
+			Label: 縦の位置
+			Tooltip:
+				'''
+				選択した隅から縦方向にピクセル単位で移動させます
+				上端/下端からさらに離すには、値を増やしてください
+				(Calamityのレイジとアドレナリンゲージから離す).
+				'''
+		}
+	}
+
+	CounterAnchor: {
+		Tooltip: ""
+
+		TopLeft: {
+			Label: 左上
+			Tooltip: ""
+		}
+
+		TopRight: {
+			Label: 右上
+			Tooltip: ""
+		}
+
+		BottomLeft: {
+			Label: 左下
+			Tooltip: ""
+		}
+
+		BottomRight: {
+			Label: 右下
+			Tooltip: ""
+		}
+	}
+
+	CounterLanguage: {
+		Tooltip: ""
+
+		Auto: {
+			Label: 自動 (ゲームの言語)
+			Tooltip: ""
+		}
+
+		English: {
+			Label: 英語
+			Tooltip: ""
+		}
+
+		German: {
+			Label: ドイツ語
+			Tooltip: ""
+		}
+
+		Italian: {
+			Label: イタリア語
+			Tooltip: ""
+		}
+
+		French: {
+			Label: フランス語
+			Tooltip: ""
+		}
+
+		Spanish: {
+			Label: スペイン語
+			Tooltip: ""
+		}
+
+		Russian: {
+			Label: ロシア語
+			Tooltip: ""
+		}
+
+		SimplifiedChinese: {
+			Label: 簡体字中国語
+			Tooltip: ""
+		}
+
+		BrazilianPortuguese: {
+			Label: ブラジルポルトガル語
+			Tooltip: ""
+		}
+
+		Polish: {
+			Label: ポーランド語
+			Tooltip: ""
+		}
+	}
+}

--- a/TranslatedMods.csv
+++ b/TranslatedMods.csv
@@ -520,3 +520,4 @@ steam_id,display_name,internal_name,version,translators,internal_note,display_no
 3439980996,积分商店（扩展版）,积分商店扩展,0.0.3,ぽぷのべり,,
 3493069544,角色创建预设CharCreationPreset,CharCreationPreset,0.1.1.2,ぽぷのべり,,
 3661809557,魔法少女ノ魔女裁判 (Magical Girl's Witch Trial),SakurabaEmaMod,1.3.2.3,d5991,,
+3743409786,CH4Z1Y's Day and Death counter,DayDeathCounter,1.3.1,d5991,,

--- a/TranslatedMods.csv
+++ b/TranslatedMods.csv
@@ -100,6 +100,7 @@ steam_id,display_name,internal_name,version,translators,internal_note,display_no
 3311152095,Capture Discs: Post-Game Add-On,PostGameCaptureDiscs,1.0.0.7,d5991,,
 2838015851,Catalyst Mod,CatalystMod,1.1.2.3,Hurugitune,全て翻訳済み。ほとんど推敲済み。,
 2687866031,Census - Town NPC Checklist,Census,0.5.2.7,まめ,,
+3743409786,CH4Z1Y's Day and Death counter,DayDeathCounter,1.3.1,d5991,,
 2927446524,Chad's Furni Reborn,TestChadsFurni,0.2,mori (new),すべて翻訳済み,
 3308342945,Challenge Vaults,ChallengeRooms,1.0.6.1,ぽぷのべり,,
 2566083800,Chat Source,ChatSource,1.1.1.4,Hurugitune,すべて翻訳済み,
@@ -520,4 +521,3 @@ steam_id,display_name,internal_name,version,translators,internal_note,display_no
 3439980996,积分商店（扩展版）,积分商店扩展,0.0.3,ぽぷのべり,,
 3493069544,角色创建预设CharCreationPreset,CharCreationPreset,0.1.1.2,ぽぷのべり,,
 3661809557,魔法少女ノ魔女裁判 (Magical Girl's Witch Trial),SakurabaEmaMod,1.3.2.3,d5991,,
-3743409786,CH4Z1Y's Day and Death counter,DayDeathCounter,1.3.1,d5991,,


### PR DESCRIPTION
## 概要

CH4Z1Y's Day and Death counter ver1.3.1の翻訳が完成しました

## 新たに翻訳した Mod

- DayDeathCounter

## 修正・更新した Mod

<!-- なし -->

## セルフチェック

- [ ] tModLoader で起動を確認した
- [ ] TranslatedMods.csv の対応する Mod の行を正しく編集した
- [ ] 機械翻訳のままではなく、全ての内容を確認し、必要に応じて修正した

## 備考

2026/06/17 18:25にd5991によって投稿 [リンク](https://discord.com/channels/@me/1242994412326355038/1516735558057984091)
2026/08/05 07:27にeva828によってアップロード